### PR TITLE
fix(dark-theme): fix wrong theme when using dark mode

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@docker/react-extension",
       "version": "0.2.0",
       "dependencies": {
-        "@docker/docker-mui-theme": "^0.0.7",
+        "@docker/docker-mui-theme": "^0.0.9",
         "@docker/extension-api-client": "^0.2.3",
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
@@ -2052,9 +2052,9 @@
       }
     },
     "node_modules/@docker/docker-mui-theme": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@docker/docker-mui-theme/-/docker-mui-theme-0.0.7.tgz",
-      "integrity": "sha512-RV4hD+1KMkNAF0I/LkKPaW56C2lC8fO2FiKpm0X8k/mrVtZ/QmF92N5olZ6JZEBSRPACCeG4MA/GkWnViRtR+A==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@docker/docker-mui-theme/-/docker-mui-theme-0.0.9.tgz",
+      "integrity": "sha512-PtsyGJ6FbD+vw2xl0vLoqhS6kuznpKufIaZM4DoOmbcoHkYtamh/HugEbKKfRM6MI7Z0+KKKnA9Liz7ECRYh8Q==",
       "peerDependencies": {
         "@mui/material": "^5.0.0",
         "react": "^17.0.0 || ^18.0.0",
@@ -17980,9 +17980,9 @@
       "requires": {}
     },
     "@docker/docker-mui-theme": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@docker/docker-mui-theme/-/docker-mui-theme-0.0.7.tgz",
-      "integrity": "sha512-RV4hD+1KMkNAF0I/LkKPaW56C2lC8fO2FiKpm0X8k/mrVtZ/QmF92N5olZ6JZEBSRPACCeG4MA/GkWnViRtR+A==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@docker/docker-mui-theme/-/docker-mui-theme-0.0.9.tgz",
+      "integrity": "sha512-PtsyGJ6FbD+vw2xl0vLoqhS6kuznpKufIaZM4DoOmbcoHkYtamh/HugEbKKfRM6MI7Z0+KKKnA9Liz7ECRYh8Q==",
       "requires": {}
     },
     "@docker/extension-api-client": {

--- a/client/package.json
+++ b/client/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
-    "@docker/docker-mui-theme": "^0.0.7",
+    "@docker/docker-mui-theme": "^0.0.9",
     "@docker/extension-api-client": "^0.2.3",
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -12,12 +12,10 @@ export function App() {
   const [ready, setReady] = useState(false);
   const [unavailable, setUnavailable] = useState(false);
   const ddClient = useDockerDesktopClient();
-  const theme = useTheme();
-  const isDarkModeEnabled = useMediaQuery('(prefers-color-scheme: dark)');
+  const isDarkModeEnabled = useMediaQuery('(prefers-color-scheme: dark)', { noSsr: true });
 
   useEffect(() => {
     let timer: number;
-    console.log((isDarkModeEnabled) ? 'dark' : 'standard');
     // sqlite3 pgadmin4.db "SELECT id,name from preferences where name='theme';" => 110|theme
     // sqlite3 pgadmin4.db "SELECT * from user_preferences where pid=112;"       => 110|1|dark
     let sqlCmd = '"import sqlite3;c=sqlite3.connect(\'/var/lib/pgadmin/pgadmin4.db\');u=c.cursor();u.execute(\'insert or replace into user_preferences (pid,uid,value) values ((SELECT id from preferences where name=?),1,?)\',(\'theme\',\''.concat((isDarkModeEnabled) ? 'dark' : 'standard').concat('\'));c.commit();u.close();c.close()"')
@@ -63,7 +61,7 @@ export function App() {
     return () => {
       clearInterval(timer);
     };
-  }, [theme]);
+  }, [isDarkModeEnabled]);
 
   return (
     <>


### PR DESCRIPTION
Hi @marcelo-ochoa!

This PR fixes the wrong theme to be applied when starting the extension.

When using the `useMediaQuery` from MUI, we need to provide if we are rendering this in the Client or in the Server side.
- [MUI Docs](https://mui.com/material-ui/react-use-media-query/#client-side-only-rendering)

I hope this fixes what you commented in https://github.com/marcelo-ochoa/sqlcl-docker-extension/issues/3