### PR TITLE
feat: add home folder for storing custom scripts; refs #14

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     container_name: pgadmin4_embedded_dd_vm
     restart: unless-stopped
     volumes:
+      - pgadmin_home:/home/pgadmin
       - pgadmin_data:/var/lib/pgadmin
     environment:
       - "PGADMIN_DEFAULT_EMAIL=user@domain.com"
@@ -25,4 +26,5 @@ services:
     ports:
       - 59080:9080
 volumes:
+  pgadmin_home:
   pgadmin_data:


### PR DESCRIPTION
Added a home folder mount to fix referenced issue #14.

Temporary workaround is to store in /var/lib/pgadmin, but this is not a suitable location.